### PR TITLE
Set up standalone .gjs/.gts syntaxes

### DIFF
--- a/languages/inline-template.json
+++ b/languages/inline-template.json
@@ -1,0 +1,11 @@
+{
+  "autoClosingPairs": [
+    { "open": "{", "close": "}"},
+    { "open": "[", "close": "]"},
+    { "open": "(", "close": ")" },
+    { "open": "'", "close": "'" },
+    { "open": "\"", "close": "\"" },
+    { "open": "<!--", "close": "-->", "notIn": ["comment", "string"] },
+    { "open": "<template>", "close": "</template>" }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -23,11 +23,13 @@
                 "id": "glimmer-js",
                 "aliases": ["Glimmer JS"],
                 "extensions": [".gjs"],
+                "configuration": "./languages/inline-template.json"
             },
             {
                 "id": "glimmer-ts",
                 "aliases": ["Glimmer TS"],
                 "extensions": [".gts"],
+                "configuration": "./languages/inline-template.json"
             }
         ],
         "grammars": [

--- a/package.json
+++ b/package.json
@@ -59,14 +59,12 @@
                 }
             },
             {
-                "injectTo": [
-                    "source.js",
-                    "source.ts"
-                ],
+                "injectTo": ["source.gts", "source.gjs"],
                 "scopeName": "inline.template",
                 "path": "./syntaxes/inline-template.json",
                 "embeddedLanguages": {
-                    "meta.embedded.block.html": "text.html.handlebars"
+                    "meta.js.embeddedTemplateWithoutArgs": "handlebars",
+                    "meta.js.embeddedTemplateWithArgs": "handlebars"
                 }
             }
         ]

--- a/package.json
+++ b/package.json
@@ -20,19 +20,33 @@
     "contributes": {
         "languages": [
             {
-                "id": "javascript",
-                "extensions": [
-                    ".gjs"
-                ]
+                "id": "glimmer-js",
+                "aliases": ["Glimmer JS"],
+                "extensions": [".gjs"],
             },
             {
-                "id": "typescript",
-                "extensions": [
-                    ".gts"
-                ]
+                "id": "glimmer-ts",
+                "aliases": ["Glimmer TS"],
+                "extensions": [".gts"],
             }
         ],
         "grammars": [
+            {
+                "language": "glimmer-js",
+                "path": "./syntaxes/glimmer-js.json",
+                "scopeName": "source.gjs",
+                "embeddedLanguages": {
+                    "source.gjs": "javascript"
+                }
+            },
+            {
+                "language": "glimmer-ts",
+                "path": "./syntaxes/glimmer-ts.json",
+                "scopeName": "source.gts",
+                "embeddedLanguages": {
+                    "source.gts": "typescript"
+                }
+            },
             {
                 "injectTo": [
                     "source.js",

--- a/syntaxes/glimmer-js.json
+++ b/syntaxes/glimmer-js.json
@@ -1,0 +1,4 @@
+{
+  "scopeName": "source.gjs",
+  "patterns": [{ "include": "source.js" }]
+}

--- a/syntaxes/glimmer-ts.json
+++ b/syntaxes/glimmer-ts.json
@@ -1,0 +1,4 @@
+{
+  "scopeName": "source.gts",
+  "patterns": [{ "include": "source.ts" }]
+}

--- a/syntaxes/inline-template.json
+++ b/syntaxes/inline-template.json
@@ -1,6 +1,6 @@
 {
   "fileTypes": [],
-  "injectionSelector": "L:source.js -comment, L:source.ts -comment",
+  "injectionSelector": "L:source.gjs -comment, L:source.gts -comment",
   "patterns": [
     {
       "name": "meta.js.embeddedTemplateWithoutArgs",
@@ -61,27 +61,27 @@
         {
           "begin": "(?<=\\<template)",
           "end": "(?=\\>)",
-					"patterns": [
-						{
-							"include": "text.html.handlebars#tag-stuff"
-						}
-					]
+          "patterns": [
+            {
+              "include": "text.html.handlebars#tag-stuff"
+            }
+          ]
         },
         {
-					"begin": "(>)",
-					"beginCaptures": {
-						"1": {
-							"name": "punctuation.definition.tag.end.js"
-						}
-					},
-					"end": "(?=</template>)",
-					"contentName": "meta.html.embedded.block",
-					"patterns": [
-						{
-							"include": "text.html.handlebars"
-						}
-					]
-				}
+          "begin": "(>)",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.definition.tag.end.js"
+            }
+          },
+          "end": "(?=</template>)",
+          "contentName": "meta.html.embedded.block",
+          "patterns": [
+            {
+              "include": "text.html.handlebars"
+            }
+          ]
+        }
       ]
     }
   ],


### PR DESCRIPTION
Currently the way this extension supports syntax highlighting `.gjs` and `.gts` files is by telling Code to treat them in all ways as though they were actually just `.js` and `.ts` files respectively. While this does get us syntax highlighting, it unfortunately causes trouble when the editor attempts to apply other tooling (ESLint, Prettier, `tsserver`, etc) to those files—spurious red squigglies, unusual autoformatting, and so on.

This change instead sets up `.gjs` and `.gts` to map to their own dedicated filetypes which, syntactically, immediately just delegate to the normal `.js`/`.ts` grammar. That also allows us to target the `<template>` grammar injection to only apply in `.gjs`/`.gts` files, rather than all JS/TS scripts across the board.

One note: due to https://github.com/microsoft/vscode/issues/133397, we need to explicitly specify `autoClosingPairs` for `.gjs` and `.gts` files, while otherwise they would have been inherited automatically from the source languages for the embedding. This ended up working out, though, as it gives us a place to add `<template>`/`</template>` as a custom pair for those languages.

| Before | After |
| - | - |
| ![image](https://user-images.githubusercontent.com/108688/151180921-7ca98fc2-ae14-4045-b863-7eb7fd935c47.png) | ![image](https://user-images.githubusercontent.com/108688/151180719-4ae29769-cb5c-4db0-b068-d99300135179.png) |