### PR TITLE
Cut a release for Glimmer file icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-glimmer",
     "displayName": "vscode-glimmer",
     "description": "VSCode extension for glimmer",
-    "version": "0.0.4",
+    "version": "0.0.5",
     "license": "MIT",
     "publisher": "chiragpat",
     "repository": {


### PR DESCRIPTION
Glimmer file icons have been merged in https://github.com/chiragpat/vscode-glimmer/pull/7.

I'd love to use them without relying on a fork. Could a version be cut and published?