### PR TITLE
fix: skip highlighting in strings

### DIFF
--- a/syntaxes/inline-template.json
+++ b/syntaxes/inline-template.json
@@ -1,6 +1,6 @@
 {
   "fileTypes": [],
-  "injectionSelector": "L:source.gjs -comment, L:source.gts -comment",
+  "injectionSelector": "L:source.gjs -comment -string, L:source.gts -comment -string",
   "patterns": [
     {
       "name": "meta.js.embeddedTemplateWithoutArgs",


### PR DESCRIPTION
Currently pattern matching for `inline-template` is done within strings. This can cause issues if a string contains `<template>`.

Before:

<img width="287" alt="image" src="https://github.com/chiragpat/vscode-glimmer/assets/10243652/99ef33cf-4b01-445c-be01-36afd153190f">


After:

<img width="287" alt="image" src="https://github.com/chiragpat/vscode-glimmer/assets/10243652/1b69912a-3ee8-4448-802c-5dced61db61e">


Fixes #10 